### PR TITLE
replace prometheus with influxdb

### DIFF
--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -22,20 +22,27 @@ services:
       PYTHONUNBUFFERED: 1
     command: "uv run minerva1.py"
 
-  prometheus:
+  influxdb:
     profiles:
       - metrics_backend
-    image: prom/prometheus:latest
-    container_name: prometheus
+    image: influxdb:2.7
+    container_name: influxdb
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z
-    command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
+      - ./influxdb/data:/var/lib/influxdb2:Z
 #    ports:
-#      - "9090:9090"
+#      - "8086:8086"
     network_mode: host
 #    networks:
 #      - telemetry_net
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: secretpassword
+      DOCKER_INFLUXDB_INIT_ORG: example_org
+      DOCKER_INFLUXDB_INIT_BUCKET: telem_bucket
+      DOCKER_INFLUXDB_INIT_RETENTION: 0
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: admintoken
+
 
   grafana:
     profiles:

--- a/infra/grafana/dashboards/dcx.json
+++ b/infra/grafana/dashboards/dcx.json
@@ -16,7 +16,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 0,
       "gridPos": {
         "h": 8,
@@ -112,7 +112,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -218,7 +218,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -314,7 +314,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -401,7 +401,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -507,7 +507,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -623,7 +623,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -710,7 +710,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 5,

--- a/infra/grafana/dashboards/orbital_launch.json
+++ b/infra/grafana/dashboards/orbital_launch.json
@@ -16,7 +16,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 0,
       "gridPos": {
         "h": 10,
@@ -112,7 +112,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 10,
@@ -218,7 +218,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 10,
@@ -314,7 +314,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "fill": 1,
       "gridPos": {
         "h": 10,

--- a/infra/grafana/provisioning/datasources/prometheus.yaml
+++ b/infra/grafana/provisioning/datasources/prometheus.yaml
@@ -1,11 +1,14 @@
 apiVersion: 1
 
 datasources:
-  - name: Prometheus
-    type: prometheus
+  - name: InfluxDB
+    type: influxdb
     access: proxy
-    url: http://localhost:9090
+    url: http://localhost:8086
     isDefault: true
-    editable: false
     jsonData:
-      timeInterval: "100ms"
+      version: "Flux"
+      organization: "example_org"
+      defaultBucket: "telem_bucket"
+    secureJsonData:
+      token: "admintoken"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "influxdb-client>=1.48.0",
     "krpc>=0.5.4",
     "matplotlib>=3.9.3",
     "numpy>=2.1.3",
-    "prometheus-client>=0.21.1",
     "scipy>=1.14.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "certifi"
+version = "2024.8.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321 },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -77,6 +86,22 @@ wheels = [
 ]
 
 [[package]]
+name = "influxdb-client"
+version = "1.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "python-dateutil" },
+    { name = "reactivex" },
+    { name = "setuptools" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/47/b756380917cb4b968bd871fc006128e2cc9897fb1ab4bcf7d108f9601e78/influxdb_client-1.48.0.tar.gz", hash = "sha256:414d5b5eff7d2b6b453f33e2826ea9872ea04a11996ba9c8604b0c1df57c8559", size = 386415 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/b3/1edc89584b8d1bc5226cf508b67ab64da3ba83041cab348861e6f4392326/influxdb_client-1.48.0-py3-none-any.whl", hash = "sha256:410db15db761df7ea98adb333c7a03f05bcc2ceef4830cefb7071b888be2b827", size = 746177 },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -130,19 +155,19 @@ name = "ksp-krpc-rocket-avionics"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "influxdb-client" },
     { name = "krpc" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "prometheus-client" },
     { name = "scipy" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "influxdb-client", specifier = ">=1.48.0" },
     { name = "krpc", specifier = ">=0.5.4" },
     { name = "matplotlib", specifier = ">=3.9.3" },
     { name = "numpy", specifier = ">=2.1.3" },
-    { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "scipy", specifier = ">=1.14.1" },
 ]
 
@@ -269,15 +294,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.21.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/14/7d0f567991f3a9af8d1cd4f619040c93b68f09a02b6d0b6ab1b2d1ded5fe/prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb", size = 78551 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/c2/ab7d37426c179ceb9aeb109a85cda8948bb269b7561a0be870cc656eefe4/prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301", size = 54682 },
-]
-
-[[package]]
 name = "protobuf"
 version = "5.29.1"
 source = { registry = "https://pypi.org/simple" }
@@ -313,6 +329,18 @@ wheels = [
 ]
 
 [[package]]
+name = "reactivex"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/63/f776322df4d7b456446eff78c4e64f14c3c26d57d46b4e06c18807d5d99c/reactivex-4.0.4.tar.gz", hash = "sha256:e912e6591022ab9176df8348a653fe8c8fa7a301f26f9931c9d8c78a650e04e8", size = 119177 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/3f/2ed8c1b8fe3fc2ed816ba40554ef703aad8c51700e2606c139fcf9b7f791/reactivex-4.0.4-py3-none-any.whl", hash = "sha256:0004796c420bd9e68aad8e65627d85a8e13f293de76656165dffbcb3a0e3fb6a", size = 217791 },
+]
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -340,10 +368,37 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "75.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz", hash = "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6", size = 1337429 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/21/47d163f615df1d30c094f6c8bbb353619274edccf0327b185cc2493c2c33/setuptools-75.6.0-py3-none-any.whl", hash = "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d", size = 1224032 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338 },
 ]


### PR DESCRIPTION
# What

Replace prometheus with influxdb for metrics DB.

# Why

Prometheus and InfluxDB are similar but have different ingestion mechanisms which impact their scalability differently.

Prometheus works by polling an HTTP endpoint of its metric sources, a `pull` model.

InfluxDB works by clients sending data to it over an HTTP endpoint, a `push` model.

Additionally there are differing querying languages and capabilities, with InfluxDB having a more SQL like query language than Prometheus.

# Current state

Everything piped together ok in this iteration, except dashboards, as dashboard queries effectively need to be re-written to use flux (the sql like influx query language).

Enum impl would probably need to be done in code now instead of delegating it to the prom_client/promdb

Basically need something so when we `publish_enum_metric` for some value, it does the work to set the value of that enum to 1 and all other enum values to 0

Or we refactor the publish_enum behavior to be a tag we put onto other metrics but that would be a more wide reaching change.

Alternatively could store the enum value as a string, though this may not play nice with the state timeline component on the dashboard. if this works it is probably lowest effort for future maintenance though

Note also the prometheus client is a pure python impl with no transitive dependencies, while influx client requires addition of 5 transitive dependencies.