### PR TITLE
refactor avionics vehicle telem reads to use the stream API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ flowchart TB
   avionics <-- commands and telem --> kRPC
   
 ```
+
+kRPC interactions is split into Protobuf over TCP on 127.0.0.1:50000 and a stream server at 127.0.0.1:50001.
+
+With the stream server, you can get the "latest" value available for a telemetry item, without paying for blocking RPC actions to the kRPC backend.
+RPC actions to the kRPC backend can take tens of milliseconds in the worst cases. 
+With the real-time "frame time budget" for the 50hz avionics being only 20ms, tens of milliseconds can quickly lead to frame overruns. 

--- a/launch_utils.py
+++ b/launch_utils.py
@@ -239,10 +239,7 @@ def abort_steering(vessel, mission_params, conn, crew_vehicle):
     else:
         quit()
 
-def throttle_from_twr(vessel, twr_desired):
-    m0 =  vessel.mass
-    g = vessel.orbit.body.surface_gravity
-    # twr = thrust/(m0*g)
+def throttle_from_twr(mass, g, max_thrust, twr_desired):
     # thrust = twr*m0*g
-    return twr_desired*m0*g/(vessel.max_thrust)
+    return twr_desired*mass*g/(max_thrust)
         

--- a/steering_logic.py
+++ b/steering_logic.py
@@ -174,22 +174,21 @@ def _calculate_landing_burn_time(fpa, v_inf, h_inf, ht, g, available_thrust, mas
     return 0.95 * (v_inf / a) - (v_inf / (available_thrust / mass))
 
 
-def calculate_landing_burn_time(vessel, telem_viz, g, engine_offset):
-    srf_frame = vessel.orbit.body.reference_frame
-    r = vessel.position(srf_frame)
-    v = vessel.velocity(srf_frame)
+def calculate_landing_burn_time(r, v, mass, speed, surface_altitude, available_thrust, telem_viz, g, engine_offset):
+    # srf_frame = vessel.orbit.body.reference_frame
+    # r = vessel.position(srf_frame)
+    # v = vessel.velocity(srf_frame)
     drag_scale = 0.42
 
     #while not landing_burn_flag:
-    m0 = vessel.mass
-    v_inf = vessel.flight(srf_frame).speed
-    h_inf = vessel.flight().surface_altitude + engine_offset
+    v_inf = speed
+    h_inf = surface_altitude + engine_offset
     ht = 20 # target stopping altitude
 
     with telem_viz.get_histogram_metric('get_flight_path_angle').time():
         fpa = get_flight_path_angle(r, v)
     with telem_viz.get_histogram_metric('calc_lb_final_math').time():
-        tb = _calculate_landing_burn_time(fpa, v_inf, h_inf, ht, g, vessel.available_thrust, vessel.mass)
+        tb = _calculate_landing_burn_time(fpa, v_inf, h_inf, ht, g, available_thrust, mass)
     return tb
             
 def landing_gate(vessel, telem, pid):


### PR DESCRIPTION
# Caution
only migrated 1 scenario in this iteration (expended flight env hop test) and focused only on GNC mode 1-3, where many overruns were observed previously. all other avionics packages are broke b/c of the interface changes.

# What

Use the kRPC streaming service for telemetry reads used for decision making in the avionics.

# Why

Nearly completely eliminate overruns in avionics, leading to more deterministic and predictable behavior, as well as provide more room for future complexity additions to the various control mode's algorithms.

# More

this is mostly a POC to measure impact, should proably merge this with the Telemetry and/or KSPTelemetry class for an operationalized solution

the impact of this is nearly 0 overruns at 50hz, with exception of ~20% overruns in mode 2a (potentially due to linear algebra or lots of RPC set calls). at 40hz there are basically no overruns after this change.

see also https://krpc.github.io/krpc/python/client.html#streaming-data-from-the-server

Additionally it results in ~67k less RPC calls (~3MB saved on reads)

## Graphs

### After Change (50hz)

Note below the p95 function time never spikes above the 1ms measurement floor, except a spike at the beginning of the script

![DCX_after_RPC_optimization_3](https://github.com/user-attachments/assets/be750b8b-4cd6-4141-963a-b07071286d92)

![DCX_after_RPC_optimization_landing_rpc_stats](https://github.com/user-attachments/assets/dc06fea6-8ca7-4bc0-a12d-42ad294090df)

![DCX_RPC_totals_after_RPC-optimization](https://github.com/user-attachments/assets/4190e4dd-d0b0-451a-bb8e-88f351fffbcb)

![DCX_after_RPC_optimization_fn_timing](https://github.com/user-attachments/assets/ed1e2745-fa8e-4810-9cbd-411d5a8dfcda)

### Before Change (50hz)

![DCX_Before_RPC_optimization_fixed_300m](https://github.com/user-attachments/assets/9ba1dd5e-13b6-4e4b-ac83-82596ef008e5)

![DCX_Before_RPC_optimization_fixed_dashboard](https://github.com/user-attachments/assets/1933034a-002d-4e91-86d8-c0ee2aebe80c)

![DCX_Before_RPC_optimization_fixed_final_stats](https://github.com/user-attachments/assets/d9edea37-11e1-45ea-9290-d3cf7e3e6f27)

![DCX_Before_RPC_optimization_fixed_gnc_timings](https://github.com/user-attachments/assets/5acf8e74-51ab-4f9c-b2ae-fc64948d9589)


